### PR TITLE
Added Config for Group Blip on Map

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -162,20 +162,25 @@ end
 local function spawnBlips()
     local blipConfigs = lib.callback.await('md-jobs:server:getBlips', false)
     for jobName, blipConfig in pairs(blipConfigs) do
-        local blipInfo = blipConfig.info
-        if blips[jobName] ~= nil then
-            if DoesBlipExist(blips[jobName]) then
+        local blipInfo = blipConfig[1] or blipConfig.info
+        if blipInfo and blipInfo.loc then
+            if blips[jobName] ~= nil and DoesBlipExist(blips[jobName]) then
                 RemoveBlip(blips[jobName])
+                blips[jobName] = nil
             end
-            blips[jobName] = nil
+            local blip = AddBlipForCoord(blipInfo.loc.x, blipInfo.loc.y, blipInfo.loc.z)
+            SetBlipSprite(blip, blipInfo.sprite or 52)
+            SetBlipScale(blip, blipInfo.scale or 0.8)
+            SetBlipColour(blip, blipInfo.col or blipInfo.color or 0)
+            SetBlipDisplay(blip, blipInfo.disp or 4)
+            if Config.GroupBlips and blipInfo.category then
+                SetBlipCategory(blip, blipInfo.category)
+            end
+            BeginTextCommandSetBlipName("STRING")
+            AddTextComponentString(blipInfo.label or jobName)
+            EndTextCommandSetBlipName(blip)
+            blips[jobName] = blip
         end
-        blips[jobName] = CreateBlip(blipInfo.loc, {
-            sprite = blipInfo.sprite or 52,
-            display = 4,
-            scale = blipInfo.scale or 0.8,
-            color = blipInfo.color or 2,
-            label = blipInfo.label or 'Lazy Ass'
-        }, true, false)
     end
 end
 
@@ -784,3 +789,4 @@ CreateThread(function()
         end
     end
 end)
+

--- a/client/client.lua
+++ b/client/client.lua
@@ -161,25 +161,34 @@ end
 --- @return nil
 local function spawnBlips()
     local blipConfigs = lib.callback.await('md-jobs:server:getBlips', false)
+    local registeredCategories = {}
+
     for jobName, blipConfig in pairs(blipConfigs) do
-        local blipInfo = blipConfig[1] or blipConfig.info
-        if blipInfo and blipInfo.loc then
-            if blips[jobName] ~= nil and DoesBlipExist(blips[jobName]) then
+        local blipInfo = blipConfig.info
+        if blips[jobName] ~= nil then
+            if DoesBlipExist(blips[jobName]) then
                 RemoveBlip(blips[jobName])
-                blips[jobName] = nil
             end
-            local blip = AddBlipForCoord(blipInfo.loc.x, blipInfo.loc.y, blipInfo.loc.z)
-            SetBlipSprite(blip, blipInfo.sprite or 52)
-            SetBlipScale(blip, blipInfo.scale or 0.8)
-            SetBlipColour(blip, blipInfo.col or blipInfo.color or 0)
-            SetBlipDisplay(blip, blipInfo.disp or 4)
-            if Config.GroupBlips and blipInfo.category then
-                SetBlipCategory(blip, blipInfo.category)
+            blips[jobName] = nil
+        end
+
+        blips[jobName] = CreateBlip(blipInfo.loc, {
+            sprite = blipInfo.sprite or 52,
+            display = blipInfo.disp or 4,
+            scale  = blipInfo.scale or 0.8,
+            color  = blipInfo.color or 2,
+            label  = blipInfo.label or jobName
+        }, true, false)
+
+        if Config.GroupBlips and blipInfo.category then
+            SetBlipCategory(blips[jobName], blipInfo.category)
+
+            if not registeredCategories[blipInfo.category] then
+                local catName = Config.CategoryNames and Config.CategoryNames[blipInfo.category]
+                    or ("Category " .. blipInfo.category)
+                AddTextEntry("BLIP_CAT_" .. blipInfo.category, catName)
+                registeredCategories[blipInfo.category] = true
             end
-            BeginTextCommandSetBlipName("STRING")
-            AddTextComponentString(blipInfo.label or jobName)
-            EndTextCommandSetBlipName(blip)
-            blips[jobName] = blip
         end
     end
 end
@@ -789,4 +798,5 @@ CreateThread(function()
         end
     end
 end)
+
 

--- a/server/locations/burgershot_uniqx.lua
+++ b/server/locations/burgershot_uniqx.lua
@@ -14,7 +14,7 @@ Jobs['burgershot'] = {
         vec3(-1186.98, -877.53, 13.85)
     },
     Blip = {
-        { sprite = 106, color = 2, scale = 0.5, label = 'Burger Shot', loc = vec3(-1178.93, -888.79, 13.95), category = 15 },
+        { sprite = 106, color = 2, scale = 0.5, label = 'Burger Shot', loc = vec3(-1178.93, -888.79, 13.95), category = 15},
     },
     closedShops = {
         { ped = 'csb_burgerdrug', loc = vector4(-1194.88, -894.07, 12.89, 352), label = 'Burgershot Shop' }

--- a/server/locations/burgershot_uniqx.lua
+++ b/server/locations/burgershot_uniqx.lua
@@ -14,7 +14,7 @@ Jobs['burgershot'] = {
         vec3(-1186.98, -877.53, 13.85)
     },
     Blip = {
-        { sprite = 106, color = 2, scale = 0.5, label = 'Burger Shot', loc = vec3(-1178.93, -888.79, 13.95) },
+        { sprite = 106, color = 2, scale = 0.5, label = 'Burger Shot', loc = vec3(-1178.93, -888.79, 13.95), category = 15 },
     },
     closedShops = {
         { ped = 'csb_burgerdrug', loc = vector4(-1194.88, -894.07, 12.89, 352), label = 'Burgershot Shop' }

--- a/server/unusedLocations.lua/Deerdiner_dippzy.lua
+++ b/server/unusedLocations.lua/Deerdiner_dippzy.lua
@@ -2,7 +2,7 @@ Jobs['deerdiner'] = {
     CateringEnabled = true,
     closedShopsEnabled = true,
     Blip = {
-        {sprite = 469, color = 2, scale = 0.8, label = 'Deer Diner', loc = vector3(454.46, 131.0, 99.4)},
+        {sprite = 469, color = 2, scale = 0.8, label = 'Deer Diner', loc = vector3(454.46, 131.0, 99.4), category = 15 },
     },
     closedShops = {
         {ped = 'mp_m_freemode_01', loc = vec4(454.52, 131.05, 99.4, 151.87), label = 'Deer Diner Shop'}
@@ -140,4 +140,5 @@ Jobs['deerdiner'] = {
         coffee = {anim = 'eat', label = 'Eating', add = {hunger = 10}},
         
     },
+
 }

--- a/server/unusedLocations.lua/Deerdiner_dippzy.lua
+++ b/server/unusedLocations.lua/Deerdiner_dippzy.lua
@@ -2,7 +2,7 @@ Jobs['deerdiner'] = {
     CateringEnabled = true,
     closedShopsEnabled = true,
     Blip = {
-        {sprite = 469, color = 2, scale = 0.8, label = 'Deer Diner', loc = vector3(454.46, 131.0, 99.4), category = 15 },
+        {sprite = 469, color = 2, scale = 0.8, label = 'Deer Diner', loc = vector3(454.46, 131.0, 99.4), category = 15},
     },
     closedShops = {
         {ped = 'mp_m_freemode_01', loc = vec4(454.52, 131.05, 99.4, 151.87), label = 'Deer Diner Shop'}
@@ -142,3 +142,4 @@ Jobs['deerdiner'] = {
     },
 
 }
+

--- a/server/unusedLocations.lua/beanmachine_brambi.lua
+++ b/server/unusedLocations.lua/beanmachine_brambi.lua
@@ -4,7 +4,7 @@ Jobs['beanmachine'] = {
     CateringEnabled = true,
     closedShopsEnabled = true,
     Blip = {
-        {sprite = 214, color = 2, scale = 0.5, label = 'Bean Machine', loc = vector4(336.74, -778.19, 29.26, 74.91)},
+        {sprite = 214, color = 2, scale = 0.5, label = 'Bean Machine', loc = vector4(336.74, -778.19, 29.26, 74.91), category = 17},
     },
     closedShops = {
         {ped = 'A_F_Y_Bevhills_05', loc = vector4(336.74, -778.19, 28.26, 74.91), label = 'Bean Machine Shop Two'}
@@ -103,4 +103,5 @@ Jobs['beanmachine'] = {
         tiramasu_coffee     = {anim = 'drink',  label = 'Drinking', add = {thirst = 10}},
         vanilla_frappe      = {anim = 'drink',  label = 'Drinking', add = {thirst = 10}},
     },
+
 }

--- a/server/unusedLocations.lua/beanmachine_gabz.lua
+++ b/server/unusedLocations.lua/beanmachine_gabz.lua
@@ -2,7 +2,7 @@ Jobs['beanmachine'] = {
     CateringEnabled = true,
     closedShopsEnabled = false,
     Blip = {
-        {sprite = 214, color = 2, scale = 0.5, label = 'Bean Machine', loc = vec3(112.27, -1042.8, 29.28)},
+        {sprite = 214, color = 2, scale = 0.5, label = 'Bean Machine', loc = vec3(112.27, -1042.8, 29.28), category = 17},
     },
     closedShops = {
         {ped = 'mp_m_freemode_01', loc = vec4(112.27, -1042.8, 29.28, 62.86), label = 'Bean Machine Shop'}
@@ -119,4 +119,5 @@ Jobs['beanmachine'] = {
         cold_brew = {anim = 'drink', label = 'Drinking', add = {thirst = 10}},
         
     },
+
 }

--- a/server/unusedLocations.lua/beanmachine_rflx.lua
+++ b/server/unusedLocations.lua/beanmachine_rflx.lua
@@ -4,7 +4,7 @@ Jobs['beanmachine'] = {
     CateringEnabled = true,
     closedShopsEnabled = true,
     Blip = {
-        {sprite = 214, color = 2, scale = 0.5, label = 'Bean Machine', loc = vector4(278.03, -963.77, 29.39, 351.03)},
+        {sprite = 214, color = 2, scale = 0.5, label = 'Bean Machine', loc = vector4(278.03, -963.77, 29.39, 351.03), category = 17},
     },
     closedShops = {
         {ped = 'mp_m_freemode_01', loc = vec4(279.09, -963.87, 29.4, 358.69), label = 'Bean Machine Cafe'}
@@ -114,4 +114,5 @@ Jobs['beanmachine'] = {
         hazelnut_latte = {anim = 'drink', label = 'Drinking', add = {thirst = 10}},
         cold_brew = {anim = 'drink', label = 'Drinking', add = {thirst = 10}},
     },
+
 }

--- a/server/unusedLocations.lua/bestbudz.lua
+++ b/server/unusedLocations.lua/bestbudz.lua
@@ -1,10 +1,9 @@
 -- https://www.gta5-mods.com/maps/mlo-legion-weed-clinic
-
 Jobs['bestbudz'] = {
     CateringEnabled = true,
     closedShopsEnabled = true,
     Blip = {
-        {sprite = 469, color = 2, scale = 0.8, label = 'Best Budz', loc = vec3(381.92, -833.4, 29.29)},
+        {sprite = 469, color = 2, scale = 0.8, label = 'Best Budz', loc = vec3(381.92, -833.4, 29.29), category = 18},
     },
     closedShops = {
         {ped = 'mp_m_freemode_01', loc = vec4(381.92, -833.4, 29.29, 184.21), label = 'Best Budz Shop'}
@@ -153,4 +152,5 @@ Jobs['bestbudz'] = {
         joint_white_widow = {anim = 'smoke2', label = 'Smoking', add = {hunger = -3, stress = -10}},
         weed_gummies = {anim = 'eat', label = 'Eating', add = {hunger = 1, stress = -10}},
     },
+
 }

--- a/server/unusedLocations.lua/burgershot_gabz.lua
+++ b/server/unusedLocations.lua/burgershot_gabz.lua
@@ -2,7 +2,7 @@ Jobs['burgershot'] = {
     CateringEnabled = true,
     closedShopsEnabled = true,
     Blip = {
-        {sprite = 106, color = 2, scale = 0.5, label = 'Burger Shot', loc = vec3(-1178.93, -888.79, 13.95), category = 15 },
+        {sprite = 106, color = 2, scale = 0.5, label = 'Burger Shot', loc = vec3(-1178.93, -888.79, 13.95), category = 15},
     },
     closedShops = {
         {ped = 'mp_m_freemode_01', loc = vec4(-1178.93, -888.79, 13.95, 304.48), label = 'Burgershot Shop'}
@@ -168,3 +168,4 @@ Jobs['burgershot'] = {
     },
 
 }
+

--- a/server/unusedLocations.lua/burgershot_gabz.lua
+++ b/server/unusedLocations.lua/burgershot_gabz.lua
@@ -2,7 +2,7 @@ Jobs['burgershot'] = {
     CateringEnabled = true,
     closedShopsEnabled = true,
     Blip = {
-        {sprite = 106, color = 2, scale = 0.5, label = 'Burger Shot', loc = vec3(-1178.93, -888.79, 13.95)},
+        {sprite = 106, color = 2, scale = 0.5, label = 'Burger Shot', loc = vec3(-1178.93, -888.79, 13.95), category = 15 },
     },
     closedShops = {
         {ped = 'mp_m_freemode_01', loc = vec4(-1178.93, -888.79, 13.95, 304.48), label = 'Burgershot Shop'}
@@ -166,4 +166,5 @@ Jobs['burgershot'] = {
         ecola = {anim = 'drink', label = 'Drinking', add = {thirst = 10}},
         sprunk = {anim = 'drink', label = 'Drinking', add = {thirst = 10}},
     },
+
 }

--- a/server/unusedLocations.lua/hookies_dippzy.lua
+++ b/server/unusedLocations.lua/hookies_dippzy.lua
@@ -3,7 +3,7 @@ Jobs['hookies'] = {
     CateringEnabled = true,
     closedShopsEnabled = true,
     Blip = {
-        {sprite = 214, color = 2, scale = 0.5, label = 'Hookies', loc = vector3(-2187.99, 4290.71, 49.17)},
+        {sprite = 214, color = 2, scale = 0.5, label = 'Hookies', loc = vector3(-2187.99, 4290.71, 49.17), category = 15 },
     },
     closedShops = {
         {ped = 'mp_m_freemode_01', loc = vec4(-2191.51, 4285.47, 49.18, 156.08), label = 'Hookies Shop'}
@@ -153,4 +153,5 @@ Jobs['hookies'] = {
         seafood_lobster_plate = {anim = 'eat', label = 'Eating', add = {hunger = 10}},
         sprunk = {anim = 'drink', label = 'Drinking', add = {thirst = 10}},
     },
+
 }

--- a/server/unusedLocations.lua/hookies_dippzy.lua
+++ b/server/unusedLocations.lua/hookies_dippzy.lua
@@ -3,7 +3,7 @@ Jobs['hookies'] = {
     CateringEnabled = true,
     closedShopsEnabled = true,
     Blip = {
-        {sprite = 214, color = 2, scale = 0.5, label = 'Hookies', loc = vector3(-2187.99, 4290.71, 49.17), category = 15 },
+        {sprite = 214, color = 2, scale = 0.5, label = 'Hookies', loc = vector3(-2187.99, 4290.71, 49.17), category = 15},
     },
     closedShops = {
         {ped = 'mp_m_freemode_01', loc = vec4(-2191.51, 4285.47, 49.18, 156.08), label = 'Hookies Shop'}
@@ -155,3 +155,4 @@ Jobs['hookies'] = {
     },
 
 }
+

--- a/server/unusedLocations.lua/hornys_gabz.lua
+++ b/server/unusedLocations.lua/hornys_gabz.lua
@@ -2,7 +2,7 @@ Jobs['hornys'] = {
     CateringEnabled = true,
     closedShopsEnabled = true,
     Blip = {
-        {sprite = 80, color = 2, scale = 0.5, label = 'hornys', loc = vector4(1251.36, -353.5, 74.02, 96.8)},
+        {sprite = 80, color = 2, scale = 0.5, label = 'hornys', loc = vector4(1251.36, -353.5, 74.02, 96.8), category = 15 },
     },
     closedShops = {
         {ped = 'mp_m_freemode_01', loc = vec4(1239.19, -367.96, 69.21, 217.86), label = 'Horny Little Shop'}
@@ -134,4 +134,5 @@ Jobs['hornys'] = {
         sirloin_burger = {anim = 'eat', label = 'Eating', add = {hunger = 10}},
         wings = {anim = 'eat', label = 'Eating', add = {hunger = 10}},
     },
+
 }

--- a/server/unusedLocations.lua/hornys_gabz.lua
+++ b/server/unusedLocations.lua/hornys_gabz.lua
@@ -2,7 +2,7 @@ Jobs['hornys'] = {
     CateringEnabled = true,
     closedShopsEnabled = true,
     Blip = {
-        {sprite = 80, color = 2, scale = 0.5, label = 'hornys', loc = vector4(1251.36, -353.5, 74.02, 96.8), category = 15 },
+        {sprite = 80, color = 2, scale = 0.5, label = 'hornys', loc = vector4(1251.36, -353.5, 74.02, 96.8), category = 15},
     },
     closedShops = {
         {ped = 'mp_m_freemode_01', loc = vec4(1239.19, -367.96, 69.21, 217.86), label = 'Horny Little Shop'}
@@ -136,3 +136,4 @@ Jobs['hornys'] = {
     },
 
 }
+

--- a/server/unusedLocations.lua/limeys_spike.lua
+++ b/server/unusedLocations.lua/limeys_spike.lua
@@ -3,7 +3,7 @@ Jobs['limeys'] = {
     CateringEnabled = true,
     closedShopsEnabled = true,
     Blip = {
-        {sprite = 214, color = 2, scale = 0.5, label = 'Limeys', loc = vector3(253.36, -1019.27, 29.54)},
+        {sprite = 214, color = 2, scale = 0.5, label = 'Limeys', loc = vector3(253.36, -1019.27, 29.54), category = 15 },
     },
     closedShops = {
         {ped = 'mp_m_freemode_01', loc = vec4(249.7, -1025.82, 29.25, 120.7), label = 'Limeys Juice Shop'}

--- a/server/unusedLocations.lua/limeys_spike.lua
+++ b/server/unusedLocations.lua/limeys_spike.lua
@@ -3,7 +3,7 @@ Jobs['limeys'] = {
     CateringEnabled = true,
     closedShopsEnabled = true,
     Blip = {
-        {sprite = 214, color = 2, scale = 0.5, label = 'Limeys', loc = vector3(253.36, -1019.27, 29.54), category = 15 },
+        {sprite = 214, color = 2, scale = 0.5, label = 'Limeys', loc = vector3(253.36, -1019.27, 29.54), category = 15},
     },
     closedShops = {
         {ped = 'mp_m_freemode_01', loc = vec4(249.7, -1025.82, 29.25, 120.7), label = 'Limeys Juice Shop'}

--- a/server/unusedLocations.lua/pablito_tacoshop.lua
+++ b/server/unusedLocations.lua/pablito_tacoshop.lua
@@ -2,7 +2,7 @@ Jobs['tacoshop'] = {
     CateringEnabled = true,
     closedShopsEnabled = true,
     Blip = {
-        {sprite = 469, color = 2, scale = 0.8, label = 'Taco Shop', loc = vector3(13.6, -1606.69, 29.4), category = 15 },
+        {sprite = 469, color = 2, scale = 0.8, label = 'Taco Shop', loc = vector3(13.6, -1606.69, 29.4), category = 15},
     },
     closedShops = {
         {ped = 'mp_m_freemode_01', loc = vector4(13.6, -1606.69, 29.4, 147.99), label = 'Pablito Taco Shop'}
@@ -81,3 +81,4 @@ Jobs['tacoshop'] = {
     },
 
 }
+

--- a/server/unusedLocations.lua/pablito_tacoshop.lua
+++ b/server/unusedLocations.lua/pablito_tacoshop.lua
@@ -2,7 +2,7 @@ Jobs['tacoshop'] = {
     CateringEnabled = true,
     closedShopsEnabled = true,
     Blip = {
-        {sprite = 469, color = 2, scale = 0.8, label = 'Taco Shop', loc = vector3(13.6, -1606.69, 29.4)},
+        {sprite = 469, color = 2, scale = 0.8, label = 'Taco Shop', loc = vector3(13.6, -1606.69, 29.4), category = 15 },
     },
     closedShops = {
         {ped = 'mp_m_freemode_01', loc = vector4(13.6, -1606.69, 29.4, 147.99), label = 'Pablito Taco Shop'}
@@ -79,4 +79,5 @@ Jobs['tacoshop'] = {
         ecola = {anim = 'drink', label = 'Drinking', add = {thirst = 10}},
         sprunk = {anim = 'drink', label = 'Drinking', add = {thirst = 10}},
     },
+
 }

--- a/server/unusedLocations.lua/pizzeria_gabz.lua
+++ b/server/unusedLocations.lua/pizzeria_gabz.lua
@@ -2,7 +2,7 @@ Jobs['pizzeria'] = {
     CateringEnabled = true,
     closedShopsEnabled = true,
     Blip = {
-        {sprite = 889, color = 2, scale = 0.5, label = 'pizzeria', loc = vector3(804.71, -748.85, 32.8), category = 15 },
+        {sprite = 889, color = 2, scale = 0.5, label = 'pizzeria', loc = vector3(804.71, -748.85, 32.8), category = 15},
     },
     closedShops = {
         {ped = 'mp_m_freemode_01', loc = vec4(793.87, -746.23, 27.19, 86.08), label = 'Pizzeria'}
@@ -144,3 +144,4 @@ Jobs['pizzeria'] = {
     },
 
 }
+

--- a/server/unusedLocations.lua/pizzeria_gabz.lua
+++ b/server/unusedLocations.lua/pizzeria_gabz.lua
@@ -2,7 +2,7 @@ Jobs['pizzeria'] = {
     CateringEnabled = true,
     closedShopsEnabled = true,
     Blip = {
-        {sprite = 889, color = 2, scale = 0.5, label = 'pizzeria', loc = vector3(804.71, -748.85, 32.8), category = 15},
+        {sprite = 889, color = 2, scale = 0.5, label = 'Pizzeria', loc = vector3(804.71, -748.85, 32.8), category = 15},
     },
     closedShops = {
         {ped = 'mp_m_freemode_01', loc = vec4(793.87, -746.23, 27.19, 86.08), label = 'Pizzeria'}
@@ -144,4 +144,5 @@ Jobs['pizzeria'] = {
     },
 
 }
+
 

--- a/server/unusedLocations.lua/pizzeria_gabz.lua
+++ b/server/unusedLocations.lua/pizzeria_gabz.lua
@@ -2,7 +2,7 @@ Jobs['pizzeria'] = {
     CateringEnabled = true,
     closedShopsEnabled = true,
     Blip = {
-        {sprite = 889, color = 2, scale = 0.5, label = 'pizzeria', loc = vector3(804.71, -748.85, 32.8)},
+        {sprite = 889, color = 2, scale = 0.5, label = 'pizzeria', loc = vector3(804.71, -748.85, 32.8), category = 15 },
     },
     closedShops = {
         {ped = 'mp_m_freemode_01', loc = vec4(793.87, -746.23, 27.19, 86.08), label = 'Pizzeria'}
@@ -142,4 +142,5 @@ Jobs['pizzeria'] = {
         sausage_pizza = {anim = 'eat', label = 'Eating', add = {hunger = 10}},
         veggie_pizza = {anim = 'eat', label = 'Eating', add = {hunger = 10}},
     },
+
 }

--- a/server/unusedLocations.lua/popsdiner_gabz.lua
+++ b/server/unusedLocations.lua/popsdiner_gabz.lua
@@ -2,7 +2,7 @@ Jobs['popsdiner'] = {
     CateringEnabled = true,
     closedShopsEnabled = true,
     Blip = {
-        {sprite = 267, color = 2, scale = 0.5, label = 'Pops Diner', loc = vector3(1591.95, 6447.57, 25.32), category = 15 },
+        {sprite = 267, color = 2, scale = 0.5, label = 'Pops Diner', loc = vector3(1591.95, 6447.57, 25.32), category = 15},
     },
     closedShops = {
         {ped = 'mp_m_freemode_01', loc = vector4(1591.95, 6447.57, 25.32, 143.8), label = 'Pops Diner Shop'}
@@ -125,3 +125,4 @@ Jobs['popsdiner'] = {
     },
 
 }
+

--- a/server/unusedLocations.lua/popsdiner_gabz.lua
+++ b/server/unusedLocations.lua/popsdiner_gabz.lua
@@ -2,7 +2,7 @@ Jobs['popsdiner'] = {
     CateringEnabled = true,
     closedShopsEnabled = true,
     Blip = {
-        {sprite = 267, color = 2, scale = 0.5, label = 'Pops Diner', loc = vector3(1591.95, 6447.57, 25.32)},
+        {sprite = 267, color = 2, scale = 0.5, label = 'Pops Diner', loc = vector3(1591.95, 6447.57, 25.32), category = 15 },
     },
     closedShops = {
         {ped = 'mp_m_freemode_01', loc = vector4(1591.95, 6447.57, 25.32, 143.8), label = 'Pops Diner Shop'}
@@ -123,4 +123,5 @@ Jobs['popsdiner'] = {
         popsburger = {anim = 'eat', label = 'Eating', add = {hunger = 10}},
         steak_and_potato = {anim = 'eat', label = 'Eating', add = {hunger = 10}},
     },
+
 }

--- a/server/unusedLocations.lua/pub.lua
+++ b/server/unusedLocations.lua/pub.lua
@@ -4,7 +4,7 @@ Jobs['pub'] = {
     CateringEnabled = true,
     closedShopsEnabled = true,
     Blip = {
-        {sprite = 93, color = 2, scale = 0.5, label = 'pub', loc = vector3(-578.47, -695.18, 32.52)},
+        {sprite = 93, color = 2, scale = 0.5, label = 'pub', loc = vector3(-578.47, -695.18, 32.52), category = 16},
     },
     closedShops = {
         {ped = 'mp_m_freemode_01', loc = vec4(-577.17, -678.2, 32.37, 263.23), label = 'Pub Shop'}
@@ -242,4 +242,5 @@ Jobs['pub'] = {
         vodka_soda = {anim = 'drink', label = 'Drinking', add = {thirst = 10}},
         whiskey_sour = {anim = 'eat', label = 'Eating', add = {hunger = 10}},
     },
+
 }

--- a/server/unusedLocations.lua/tequilala_base.lua
+++ b/server/unusedLocations.lua/tequilala_base.lua
@@ -2,7 +2,7 @@ Jobs['tequilala'] = {
     CateringEnabled = true,
     closedShopsEnabled = true,
     Blip = {
-        {sprite = 93, color = 2, scale = 0.5, label = 'Tequila La', loc =vec3(-554.26, 285.53, 82.18)},
+        {sprite = 93, color = 2, scale = 0.5, label = 'Tequila La', loc =vec3(-554.26, 285.53, 82.18), category = 16},
     },
     closedShops = {
         {ped = 'mp_m_freemode_01', loc = vec4(-559.73, 274.44, 83.02, 183.77), label = 'Tequila La Shop'}
@@ -79,4 +79,5 @@ Jobs['tequilala'] = {
         pisswaser_dark = {anim = 'drink', label = 'Drinking', add = {thirst = 10}},
         pisswaser_light = {anim = 'drink', label = 'Drinking', add = {thirst = 10}},
     },
+
 }

--- a/server/unusedLocations.lua/uwu_gabz.lua
+++ b/server/unusedLocations.lua/uwu_gabz.lua
@@ -2,7 +2,7 @@ Jobs['uwu'] = {
     CateringEnabled = true,
     closedShopsEnabled = true,
     Blip = {
-        {sprite = 80, color = 2, scale = 0.5, label = 'Cat Cafe', loc = vector3(-584.06, -1058.73, 22.38)},
+        {sprite = 80, color = 2, scale = 0.5, label = 'Cat Cafe', loc = vector3(-584.06, -1058.73, 22.38), category = 17},
     },
     closedShops = {
         {ped = 'mp_m_freemode_01', loc = vector4(-574.73, -1071.35, 22.33, 175.12), label = 'uwu Cafe Shop'}
@@ -170,4 +170,5 @@ Jobs['uwu'] = {
         uwu_kare_curry = {anim = 'eat', label = 'Eating', add = {hunger = 10}},
         uwu_omurice = {anim = 'eat', label = 'Eating', add = {hunger = 10}},
     },
+
 }

--- a/server/unusedLocations.lua/weedshop.lua
+++ b/server/unusedLocations.lua/weedshop.lua
@@ -6,7 +6,7 @@ Jobs['weedshop'] = {
     CateringEnabled = false,
     closedShopsEnabled = true,
     Blip = {
-        {sprite = 469, color = 2, scale = 0.8, label = 'Weed Shop', loc = vector3(374.57, -825.79, 29.05)},
+        {sprite = 469, color = 2, scale = 0.8, label = 'Weed Shop', loc = vector3(374.57, -825.79, 29.05), category = 18},
     },
     closedShops = {
         {ped = 'mp_m_freemode_01', loc = vector4(-626.02, 287.51, 82.39, 180.0), label = 'Weed Shop'}
@@ -134,3 +134,4 @@ Jobs['weedshop'] = {
         joint_white_widow = {anim = 'smoke', label = 'Smoking', add = {hunger = -3, stress = -10}},
     },
 }
+

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -22,11 +22,12 @@ Config.ClosedShopLoop = 5              -- How many minutes you want to wait for 
 Config.ClosedShopCount = 2             -- How many players you want to allow to be on duty before closed shops are active
 Config.ClosedShopFee = 0.2             -- 20% of the total price
 Config.GroupBlips = true              -- If blips should group by category on map set to true
--- Default Categories can be edited/added in the job locations luas - if you already use blip categories elsewhere make sure these numbers do not conflict with existing ones
--- 15 = Food
--- 16 = Bar
--- 17 Coffee Shop
--- 18 Weed Shop
+Config.CategoryNames = {
+    [15] = "Food",
+    [16] = "Bar",
+    [17] = "Coffee Shop",
+    [18] = "Weed Shop",
+}
 
 if Config.Framework == 'qb' then
     QBCore = exports['qb-core']:GetCoreObject()

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -21,6 +21,11 @@ Config.ClosedShopAlwaysActive = true   -- If you want to always have closed shop
 Config.ClosedShopLoop = 5              -- How many minutes you want to wait for the closed shop loop | Recommended higher than 5
 Config.ClosedShopCount = 2             -- How many players you want to allow to be on duty before closed shops are active
 Config.ClosedShopFee = 0.2             -- 20% of the total price
+Config.GroupBlips = false              -- If blips should group by category on map set to true
+-- Default Categories used in the job locations luas - if you already use blip categories elsewhere make sure these do not conflict
+-- 15 = Food
+-- 16 = Bar
+-- 17 Coffee Shop
 
 if Config.Framework == 'qb' then
     QBCore = exports['qb-core']:GetCoreObject()

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -21,7 +21,7 @@ Config.ClosedShopAlwaysActive = true   -- If you want to always have closed shop
 Config.ClosedShopLoop = 5              -- How many minutes you want to wait for the closed shop loop | Recommended higher than 5
 Config.ClosedShopCount = 2             -- How many players you want to allow to be on duty before closed shops are active
 Config.ClosedShopFee = 0.2             -- 20% of the total price
-Config.GroupBlips = false              -- If blips should group by category on map set to true
+Config.GroupBlips = true              -- If blips should group by category on map set to true
 -- Default Categories can be edited/added in the job locations luas - if you already use blip categories elsewhere make sure these numbers do not conflict with existing ones
 -- 15 = Food
 -- 16 = Bar

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -26,6 +26,7 @@ Config.GroupBlips = false              -- If blips should group by category on m
 -- 15 = Food
 -- 16 = Bar
 -- 17 Coffee Shop
+-- 18 Weed Shop
 
 if Config.Framework == 'qb' then
     QBCore = exports['qb-core']:GetCoreObject()

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -22,7 +22,7 @@ Config.ClosedShopLoop = 5              -- How many minutes you want to wait for 
 Config.ClosedShopCount = 2             -- How many players you want to allow to be on duty before closed shops are active
 Config.ClosedShopFee = 0.2             -- 20% of the total price
 Config.GroupBlips = false              -- If blips should group by category on map set to true
--- Default Categories used in the job locations luas - if you already use blip categories elsewhere make sure these do not conflict
+-- Default Categories can be edited/added in the job locations luas - if you already use blip categories elsewhere make sure these numbers do not conflict with existing ones
 -- 15 = Food
 -- 16 = Bar
 -- 17 Coffee Shop


### PR DESCRIPTION
This edit makes a change to client.lua that will allow categories to be added to blips. This allows them to show up under one tab of the map index and cycled like same named locations, instead of all job blips being ordered alphabetically.

The config change allows the script to ignore the category if grouped blips are not wanted.
Comments in config explain how to edit locations to add or change categories.

All locations with more than one shop have had categories assigned.